### PR TITLE
FIX: Mixnet Test Fail

### DIFF
--- a/decide/mixnet/models.py
+++ b/decide/mixnet/models.py
@@ -68,7 +68,7 @@ class Mixnet(models.Model):
         })
 
         if next_auths:
-            auth = next_auths.first().url
+            auth = list(next_auths)[0].url
             r = mods.post('mixnet', entry_point=path,
                            baseurl=auth, json=data)
             return r


### PR DESCRIPTION
test_multiple_auths_mock (mixnet.tests.MixnetCase) fails with the following exception: "Cannot reorder a query once a slice has been taken."
This fix prevents that exception from firing on python3.7